### PR TITLE
remove unused mathplotlib in chatstat.py

### DIFF
--- a/chatstat.py
+++ b/chatstat.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from plotly.subplots import make_subplots
 import pandas as pd
-import matplotlib.pyplot as plt
 import plotly.graph_objects as go
 from functools import wraps
 


### PR DESCRIPTION
This library was missing in requirements.txt, which prevented its use.